### PR TITLE
Correctly encode Wikipedia page titles

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -158,6 +158,8 @@ def extract_page_title(url, wp_lang):
         return None
     return urllib.unquote(url[len(prefix):].encode('utf8')).decode('utf8')
 
+def quote_page_title(title):
+    return urllib.quote(title.encode('utf8').replace(' ', '_'), '/$,:;@')
 
 _unaccent_dict = {u'Æ': u'AE', u'æ': u'ae', u'Œ': u'OE', u'œ': u'oe', u'ß': 'ss'}
 _re_latin_letter = re.compile(r"^(LATIN [A-Z]+ LETTER [A-Z]+) WITH")

--- a/wp_links_artists.py
+++ b/wp_links_artists.py
@@ -11,7 +11,7 @@ import urllib
 import time
 from mbbot.wp.wikipage import WikiPage
 from mbbot.wp.analysis import determine_country
-from utils import mangle_name, join_names, out, colored_out, bcolors, escape_query
+from utils import mangle_name, join_names, out, colored_out, bcolors, escape_query, quote_page_title
 import config as cfg
 
 engine = sqlalchemy.create_engine(cfg.MB_DB)
@@ -158,7 +158,7 @@ for artist in db.execute(query, query_params):
                 colored_out(bcolors.HEADER, ' * artist country (%s) not compatible with wiki language (%s)' % (country, wp_lang))
                 continue
 
-        url = 'http://%s.wikipedia.org/wiki/%s' % (wp_lang, urllib.quote(page_title.encode('utf8').replace(' ', '_')),)
+        url = 'http://%s.wikipedia.org/wiki/%s' % (wp_lang, quote_page_title(page_title),)
         text = 'Matched based on the name. The page mentions %s.' % (join_names('album', found_albums),)
         colored_out(bcolors.OKGREEN, ' * linking to %s' % (url,))
         out(' * edit note: %s' % (text,))

--- a/wp_links_artists_jp.py
+++ b/wp_links_artists_jp.py
@@ -8,7 +8,7 @@ from editing import MusicBrainzClient
 import pprint
 import urllib
 import time
-from utils import mangle_name, join_names, contains_text_in_script
+from utils import mangle_name, join_names, contains_text_in_script, quote_page_title
 import config as cfg
 
 engine = sqlalchemy.create_engine(cfg.MB_DB)
@@ -120,7 +120,7 @@ for id, gid, name in db.execute(query):
             continue
         if ratio < min_ratio:
             continue
-        url = 'http://ja.wikipedia.org/wiki/%s' % (urllib.quote(page_title.encode('utf8').replace(' ', '_')),)
+        url = 'http://ja.wikipedia.org/wiki/%s' % (quote_page_title(page_title),)
         text = 'Matched based on the name. The page mentions %s.' % (join_names('album', found_albums),)
         print ' * linking to %s' % (url,)
         print ' * edit note: %s' % (text,)

--- a/wp_links_artists_ko.py
+++ b/wp_links_artists_ko.py
@@ -8,7 +8,7 @@ from editing import MusicBrainzClient
 import pprint
 import urllib
 import time
-from utils import mangle_name, join_names, contains_text_in_script
+from utils import mangle_name, join_names, contains_text_in_script, quote_page_title
 import config as cfg
 
 engine = sqlalchemy.create_engine(cfg.MB_DB)
@@ -120,7 +120,7 @@ for id, gid, name in db.execute(query):
             continue
         #if ratio < min_ratio:
         #    continue
-        url = 'http://ko.wikipedia.org/wiki/%s' % (urllib.quote(page_title.encode('utf8').replace(' ', '_')),)
+        url = 'http://ko.wikipedia.org/wiki/%s' % (quote_page_title(page_title),)
         text = 'Matched based on the name. The page mentions %s.' % (join_names('album', found_albums),)
         print ' * linking to %s' % (url,)
         print ' * edit note: %s' % (text,)

--- a/wp_links_labels.py
+++ b/wp_links_labels.py
@@ -6,7 +6,7 @@ from editing import MusicBrainzClient
 import pprint
 import urllib
 import time
-from utils import mangle_name, join_names
+from utils import mangle_name, join_names, quote_page_title
 import config as cfg
 
 engine = sqlalchemy.create_engine(cfg.MB_DB)
@@ -96,7 +96,7 @@ for id, gid, name in db.execute(query):
         print ' * ratio: %s, has artists: %s, found artists: %s' % (ratio, len(artists), len(found_artists))
         if len(found_artists) < 2:
             continue
-        url = 'http://en.wikipedia.org/wiki/%s' % (urllib.quote(page_title.encode('utf8').replace(' ', '_')),)
+        url = 'http://en.wikipedia.org/wiki/%s' % (quote_page_title(page_title),)
         text = 'Matched based on the name. The page mentions %s.' % (join_names('artist', found_artists),)
         print ' * linking to %s' % (url,)
         print ' * edit note: %s' % (text,)

--- a/wp_links_rgs.py
+++ b/wp_links_rgs.py
@@ -9,7 +9,7 @@ from editing import MusicBrainzClient
 import pprint
 import urllib
 import time
-from utils import mangle_name, join_names, out, get_page_content, extract_page_title, colored_out, bcolors, escape_query
+from utils import mangle_name, join_names, out, get_page_content, extract_page_title, colored_out, bcolors, escape_query, quote_page_title
 import config as cfg
 
 engine = sqlalchemy.create_engine(cfg.MB_DB)
@@ -115,7 +115,7 @@ for rg_id, rg_gid, rg_name, ac_name, rg_type in db.execute(query, query_params):
         if not page_orig:
             continue
         page_title = title
-        url = 'http://%s.wikipedia.org/wiki/%s' % (wp_lang, urllib.quote(page_title.encode('utf8').replace(' ', '_')),)
+        url = 'http://%s.wikipedia.org/wiki/%s' % (wp_lang, quote_page_title(page_title),)
         colored_out(bcolors.HEADER, ' * trying article %s' % (title,))
         page = mangle_name(page_orig)
         if 'redirect' in page:


### PR DESCRIPTION
Wikipedia doesn't percent encode certain reserved characters (/$,:;@).
The user interface is being fixed by [1], but of course bots should
follow that, too (since they don't get corrected by JavaScript).

[1] http://tickets.musicbrainz.org/browse/MBS-4284
